### PR TITLE
Fix MovieList comparison bug

### DIFF
--- a/core/common/src/commonMain/kotlin/org/michaelbel/movies/common/list/MovieList.kt
+++ b/core/common/src/commonMain/kotlin/org/michaelbel/movies/common/list/MovieList.kt
@@ -31,20 +31,20 @@ sealed interface MovieList: SealedString {
 
         fun transform(name: String): MovieList {
             return when (name) {
-                NowPlaying().toString() -> NowPlaying()
-                Popular().toString() -> Popular()
-                TopRated().toString() -> TopRated()
-                Upcoming().toString() -> Upcoming()
+                NowPlaying().name -> NowPlaying()
+                Popular().name -> Popular()
+                TopRated().name -> TopRated()
+                Upcoming().name -> Upcoming()
                 else -> throw InvalidMovieListException
             }
         }
 
         fun name(movieList: MovieList): String {
             return when (movieList) {
-                is NowPlaying -> NowPlaying().name
-                is Popular -> Popular().name
-                is TopRated -> TopRated().name
-                is Upcoming -> Upcoming().name
+                is NowPlaying -> movieList.name
+                is Popular -> movieList.name
+                is TopRated -> movieList.name
+                is Upcoming -> movieList.name
             }
         }
     }


### PR DESCRIPTION
## Summary
- fix MovieList comparison to use name value instead of `toString`
- return existing movie list item names directly

## Testing
- `./gradlew :core:common:compileKotlinJvm --console=plain --no-daemon` *(fails: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_683f3cdec1c88324bf36a2e51721c57e