### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,11 +231,11 @@ If you find any problems or would like to suggest a feature, please feel free to
 
 
 ## Star History
-<a href="https://star-history.com/#michaelbel/movies&Date">
+<a href="https://star-history.dera.page/#michaelbel/movies&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=michaelbel/movies&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=michaelbel/movies&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=michaelbel/movies&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=michaelbel/movies&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=michaelbel/movies&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=michaelbel/movies&type=Date" />
   </picture>
 </a>
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -236,11 +236,11 @@ TMDB_API_KEY=your_own_tmdb_api_key
 
 
 ## История звездочек
-<a href="https://star-history.com/#michaelbel/movies&Date">
+<a href="https://star-history.dera.page/#michaelbel/movies&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=michaelbel/movies&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=michaelbel/movies&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=michaelbel/movies&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=michaelbel/movies&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=michaelbel/movies&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=michaelbel/movies&type=Date" />
   </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub stargazer API restrictions. This PR moves the chart to a fixed provider backed by a token-free data source so the chart renders correctly again in both the English and Russian readmes.